### PR TITLE
 fix: MoveButton 의 비공개 포스트 화면 표시 현상 해결

### DIFF
--- a/src/templates/Post.jsx
+++ b/src/templates/Post.jsx
@@ -35,6 +35,7 @@ export default ({ data, location }) => {
 };
 
 
+
 export const pageQuery = graphql`
   query BlogPostBySlug(
     $id: String!
@@ -59,22 +60,31 @@ export const pageQuery = graphql`
         tags
         series
         previewImage
+        isPrivate
       }
     }
-    previous: markdownRemark(id: { eq: $previousPostId }) {
+    previous: markdownRemark(
+      id: { eq: $previousPostId }
+      frontmatter: { isPrivate: { ne: true } }
+    ) {
       fields {
         slug
       }
       frontmatter {
         title
+        isPrivate
       }
     }
-    next: markdownRemark(id: { eq: $nextPostId }) {
+    next: markdownRemark(
+      id: { eq: $nextPostId }
+      frontmatter: { isPrivate: { ne: true } }
+    ) {
       fields {
         slug
       }
       frontmatter {
         title
+        isPrivate
       }
     }
   }


### PR DESCRIPTION
### 작업 내용 (Work Content)

- PostFooter 의 MoveButton 에 비공개 포스트로 이동할 수 있는 기능이 제공되고 있었다. 
- MoveButton 을 통해이동이 불가능하도록 막았다.
- Oops... There is no contents 😵 가 표시된다.

---

### 관련 이슈 넘버 (Related Issue Number)

#4 