### PR TITLE
refactor: 모바일 썸네일 사이즈 160px 로 축소

### DIFF
--- a/src/components/postlist/index.jsx
+++ b/src/components/postlist/index.jsx
@@ -185,8 +185,8 @@ const ImageWrapper = styled.div`
 const ImageMobileWrapper = styled.div`
   padding-top: 60px;
   padding-bottom: 60px;
-  width: 200px;
-  height: 200px;
+  width: 160px;
+  height: 160px;
   margin-left: 30px;
   overflow: hidden;
   background-repeat: no-repeat;


### PR DESCRIPTION
### 작업 내용 (Work Content)

실제 UI/UX 를 확인해보니 썸네일 비율이 160 x 160 이 눈에 더 예쁘게 들어왔다. 160 x 160 으로 수정했다.


---

### 관련 이슈 넘버 (Related Issue Number)

#9 